### PR TITLE
Proper merge of borrow management feature without squash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>2.4.4</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/library/library_management/config/AppConfig.java
+++ b/src/main/java/com/library/library_management/config/AppConfig.java
@@ -1,0 +1,4 @@
+package com.library.library_management.config;
+
+public class AppConfig {
+}

--- a/src/main/java/com/library/library_management/config/AppConfig.java
+++ b/src/main/java/com/library/library_management/config/AppConfig.java
@@ -1,4 +1,14 @@
 package com.library.library_management.config;
 
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class AppConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
 }

--- a/src/main/java/com/library/library_management/dto/BookRequest.java
+++ b/src/main/java/com/library/library_management/dto/BookRequest.java
@@ -1,4 +1,0 @@
-package com.library.library_management.dto;
-
-public record BookRequest() {
-}

--- a/src/main/java/com/library/library_management/dto/BookResponse.java
+++ b/src/main/java/com/library/library_management/dto/BookResponse.java
@@ -1,0 +1,9 @@
+package com.library.library_management.dto;
+
+public record BookResponse(
+        Long id,
+        String title,
+        String author,
+        int amount
+) {
+}

--- a/src/main/java/com/library/library_management/dto/BorrowResponse.java
+++ b/src/main/java/com/library/library_management/dto/BorrowResponse.java
@@ -1,0 +1,4 @@
+package com.library.library_management.dto;
+
+public record BorrowResponse() {
+}

--- a/src/main/java/com/library/library_management/dto/BorrowResponse.java
+++ b/src/main/java/com/library/library_management/dto/BorrowResponse.java
@@ -1,4 +1,12 @@
 package com.library.library_management.dto;
 
-public record BorrowResponse() {
+import java.time.LocalDate;
+
+public record BorrowResponse(
+        Long id,
+        Long bookId,
+        Long memberId,
+        LocalDate borrowDate,
+        LocalDate returnDate
+) {
 }

--- a/src/main/java/com/library/library_management/dto/CreateBookRequest.java
+++ b/src/main/java/com/library/library_management/dto/CreateBookRequest.java
@@ -1,0 +1,17 @@
+package com.library.library_management.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateBookRequest(
+        @NotBlank(message = "Title is required")
+        @Size(min = 3, message = "Title must be at least 3 characters")
+        @Pattern(regexp = "^[A-Z].*", message = "Title must start with a capital letter")
+        String title,
+
+        @NotBlank(message = "Author is required")
+        @Pattern(regexp = "^[A-Z][a-z]+\\s[A-Z][a-z]+$", message = "Author must be in format 'Name Surname' with capital letters")
+        String author
+) {
+}

--- a/src/main/java/com/library/library_management/dto/UpdateBookRequest.java
+++ b/src/main/java/com/library/library_management/dto/UpdateBookRequest.java
@@ -1,0 +1,22 @@
+package com.library.library_management.dto;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateBookRequest(
+        @NotBlank(message = "Title is required")
+        @Size(min = 3, message = "Title must be at least 3 characters")
+        @Pattern(regexp = "^[A-Z].*", message = "Title must start with a capital letter")
+        String title,
+
+        @NotBlank(message = "Author is required")
+        @Pattern(regexp = "^[A-Z][a-z]+\\s[A-Z][a-z]+$", message = "Author must be in format 'Name Surname' with capital letters")
+        String author,
+
+        @Min(value = 0, message = "Amount cannot be negative")
+        int amount
+) {
+}

--- a/src/main/java/com/library/library_management/dto/mapper/BookMapper.java
+++ b/src/main/java/com/library/library_management/dto/mapper/BookMapper.java
@@ -1,0 +1,4 @@
+package com.library.library_management.dto.mapper;
+
+public class BookMapper {
+}

--- a/src/main/java/com/library/library_management/dto/mapper/BookMapper.java
+++ b/src/main/java/com/library/library_management/dto/mapper/BookMapper.java
@@ -1,4 +1,37 @@
 package com.library.library_management.dto.mapper;
 
+import com.library.library_management.dto.BookResponse;
+import com.library.library_management.dto.CreateBookRequest;
+import com.library.library_management.dto.UpdateBookRequest;
+import com.library.library_management.entity.Book;
+import org.hibernate.sql.Update;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
 public class BookMapper {
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    public Book fromCreateRequest(CreateBookRequest request) {
+        return modelMapper.map(request, Book.class);
+    }
+
+    public Book fromUpdateRequest(UpdateBookRequest request) {
+        return modelMapper.map(request, Book.class);
+    }
+
+    public UpdateBookRequest toUpdateRequest(Book book) {
+        return modelMapper.map(book, UpdateBookRequest.class);
+    }
+
+    public Book fromBookResponse(BookResponse response) {
+        return modelMapper.map(response, Book.class);
+    }
+
+    public BookResponse toBookResponse(Book book) {
+        return modelMapper.map(book, BookResponse.class);
+    }
 }

--- a/src/main/java/com/library/library_management/dto/mapper/BorrowMapper.java
+++ b/src/main/java/com/library/library_management/dto/mapper/BorrowMapper.java
@@ -1,0 +1,22 @@
+package com.library.library_management.dto.mapper;
+
+import com.library.library_management.dto.BorrowResponse;
+import com.library.library_management.entity.Borrow;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BorrowMapper {
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    public Borrow fromResponse(BorrowResponse response) {
+        return modelMapper.map(response, Borrow.class);
+    }
+
+    public BorrowResponse toResponse(Borrow borrow) {
+        return modelMapper.map(borrow, BorrowResponse.class);
+    }
+}

--- a/src/main/java/com/library/library_management/dto/mapper/BorrowMapper.java
+++ b/src/main/java/com/library/library_management/dto/mapper/BorrowMapper.java
@@ -2,21 +2,18 @@ package com.library.library_management.dto.mapper;
 
 import com.library.library_management.dto.BorrowResponse;
 import com.library.library_management.entity.Borrow;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class BorrowMapper {
 
-    @Autowired
-    private ModelMapper modelMapper;
-
-    public Borrow fromResponse(BorrowResponse response) {
-        return modelMapper.map(response, Borrow.class);
-    }
-
     public BorrowResponse toResponse(Borrow borrow) {
-        return modelMapper.map(borrow, BorrowResponse.class);
+        return new BorrowResponse(
+                borrow.getId(),
+                borrow.getBook().getId(),
+                borrow.getMember().getId(),
+                borrow.getBorrowDate(),
+                borrow.getReturnDate()
+        );
     }
 }

--- a/src/main/java/com/library/library_management/entity/Borrow.java
+++ b/src/main/java/com/library/library_management/entity/Borrow.java
@@ -1,0 +1,74 @@
+package com.library.library_management.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+public class Borrow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private LocalDate borrowDate;
+
+    private LocalDate returnDate;
+
+    public Borrow() {}
+
+    public Borrow(Book book, Member member, LocalDate borrowDate) {
+        this.book = book;
+        this.member = member;
+        this.borrowDate = borrowDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public LocalDate getBorrowDate() {
+        return borrowDate;
+    }
+
+    public void setBorrowDate(LocalDate borrowDate) {
+        this.borrowDate = borrowDate;
+    }
+
+    public LocalDate getReturnDate() {
+        return returnDate;
+    }
+
+    public void setReturnDate(LocalDate returnDate) {
+        this.returnDate = returnDate;
+    }
+}

--- a/src/main/java/com/library/library_management/exception/BookNotAvailableException.java
+++ b/src/main/java/com/library/library_management/exception/BookNotAvailableException.java
@@ -1,0 +1,7 @@
+package com.library.library_management.exception;
+
+public class BookNotAvailableException extends RuntimeException {
+    public BookNotAvailableException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/library/library_management/exception/BorrowLimitExceededException.java
+++ b/src/main/java/com/library/library_management/exception/BorrowLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.library.library_management.exception;
+
+public class BorrowLimitExceededException extends RuntimeException {
+    public BorrowLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/library/library_management/exception/BorrowNotFoundException.java
+++ b/src/main/java/com/library/library_management/exception/BorrowNotFoundException.java
@@ -1,0 +1,7 @@
+package com.library.library_management.exception;
+
+public class BorrowNotFoundException extends RuntimeException {
+    public BorrowNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/library/library_management/exception/MemberNotFoundException.java
+++ b/src/main/java/com/library/library_management/exception/MemberNotFoundException.java
@@ -1,0 +1,7 @@
+package com.library.library_management.exception;
+
+public class MemberNotFoundException extends RuntimeException {
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/library/library_management/repository/BookRepository.java
+++ b/src/main/java/com/library/library_management/repository/BookRepository.java
@@ -1,4 +1,11 @@
 package com.library.library_management.repository;
 
-public interface BookRepository {
+import com.library.library_management.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+
+    Optional<Book> findByTitleAndAuthor(String title, String author);
 }

--- a/src/main/java/com/library/library_management/repository/BorrowRepository.java
+++ b/src/main/java/com/library/library_management/repository/BorrowRepository.java
@@ -1,0 +1,13 @@
+package com.library.library_management.repository;
+
+import com.library.library_management.entity.Borrow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BorrowRepository extends JpaRepository<Borrow, Long> {
+
+    boolean existsByBookIdAndReturnDateIsNull(Long bookId);
+
+    boolean existsByMemberIdAndReturnDateIsNull(Long memberId);
+
+    int countByMemberIdAndReturnDateIsNull(Long memberId);
+}

--- a/src/main/java/com/library/library_management/repository/BorrowRepository.java
+++ b/src/main/java/com/library/library_management/repository/BorrowRepository.java
@@ -3,6 +3,8 @@ package com.library.library_management.repository;
 import com.library.library_management.entity.Borrow;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BorrowRepository extends JpaRepository<Borrow, Long> {
 
     boolean existsByBookIdAndReturnDateIsNull(Long bookId);
@@ -10,4 +12,6 @@ public interface BorrowRepository extends JpaRepository<Borrow, Long> {
     boolean existsByMemberIdAndReturnDateIsNull(Long memberId);
 
     int countByMemberIdAndReturnDateIsNull(Long memberId);
+
+    List<Borrow> findByMemberIdAndReturnDateIsNull(Long memberId);
 }

--- a/src/main/java/com/library/library_management/repository/MemberRepository.java
+++ b/src/main/java/com/library/library_management/repository/MemberRepository.java
@@ -1,4 +1,7 @@
 package com.library.library_management.repository;
 
-public interface MemberRepository {
+import com.library.library_management.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/com/library/library_management/repository/MemberRepository.java
+++ b/src/main/java/com/library/library_management/repository/MemberRepository.java
@@ -1,0 +1,4 @@
+package com.library.library_management.repository;
+
+public interface MemberRepository {
+}

--- a/src/main/java/com/library/library_management/service/BookService.java
+++ b/src/main/java/com/library/library_management/service/BookService.java
@@ -3,6 +3,7 @@ package com.library.library_management.service;
 import com.library.library_management.dto.BookResponse;
 import com.library.library_management.dto.CreateBookRequest;
 import com.library.library_management.dto.UpdateBookRequest;
+import com.library.library_management.entity.Book;
 
 import java.util.List;
 
@@ -16,4 +17,8 @@ public interface BookService {
     BookResponse updateBookById(Long id, UpdateBookRequest request);
 
     void deleteBookById(Long id);
+
+    boolean existsById(Long id);
+
+    int getAmountById(Long id);
 }

--- a/src/main/java/com/library/library_management/service/BookService.java
+++ b/src/main/java/com/library/library_management/service/BookService.java
@@ -1,4 +1,19 @@
 package com.library.library_management.service;
 
+import com.library.library_management.dto.BookResponse;
+import com.library.library_management.dto.CreateBookRequest;
+import com.library.library_management.dto.UpdateBookRequest;
+
+import java.util.List;
+
 public interface BookService {
+    BookResponse createBook(CreateBookRequest request);
+
+    BookResponse getBookById(Long id);
+
+    List<BookResponse> getAllBooks();
+
+    BookResponse updateBookById(Long id, UpdateBookRequest request);
+
+    void deleteBookById(Long id);
 }

--- a/src/main/java/com/library/library_management/service/BorrowService.java
+++ b/src/main/java/com/library/library_management/service/BorrowService.java
@@ -1,0 +1,4 @@
+package com.library.library_management.service;
+
+public interface BorrowService {
+}

--- a/src/main/java/com/library/library_management/service/BorrowService.java
+++ b/src/main/java/com/library/library_management/service/BorrowService.java
@@ -1,4 +1,16 @@
 package com.library.library_management.service;
 
+import com.library.library_management.dto.BorrowResponse;
+
+import java.util.List;
+
 public interface BorrowService {
+
+    void borrowBook(Long memberId, Long bookId);
+
+    void returnBook(Long borrowId);
+
+    List<BorrowResponse> getBorrowedBooksByMember(Long memberId);
+
+    boolean isBookCurrentlyBorrowed(Long bookId);
 }

--- a/src/main/java/com/library/library_management/service/impl/BookServiceImpl.java
+++ b/src/main/java/com/library/library_management/service/impl/BookServiceImpl.java
@@ -1,4 +1,79 @@
 package com.library.library_management.service.impl;
 
-public class BookServiceImpl {
+import com.library.library_management.dto.BookResponse;
+import com.library.library_management.dto.CreateBookRequest;
+import com.library.library_management.dto.UpdateBookRequest;
+import com.library.library_management.entity.Book;
+import com.library.library_management.exception.BookNotFoundException;
+import com.library.library_management.repository.BookRepository;
+import com.library.library_management.service.BookService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class BookServiceImpl implements BookService {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Override
+    public BookResponse createBook(CreateBookRequest request) {
+        Optional<Book> existingBook = bookRepository.findByTitleAndAuthor(request.title(), request.author());
+
+        if (existingBook.isPresent()) {
+            Book presentBook = existingBook.get();
+            presentBook.setAmount(presentBook.getAmount() + 1);
+            Book savedBook = bookRepository.save(presentBook);
+            return new BookResponse(
+                    savedBook.getId(),
+                    savedBook.getTitle(),
+                    savedBook.getAuthor(),
+                    savedBook.getAmount()
+            );
+        }
+        Book book = new Book();
+        book.setTitle(request.title());
+        book.setAuthor(request.author());
+        book.setAmount(1);
+        Book savedBook = bookRepository.save(book);
+        return new BookResponse(savedBook.getId(), savedBook.getTitle(), savedBook.getAuthor(), savedBook.getAmount());
+    }
+
+    @Override
+    public BookResponse getBookById(Long id) {
+        Book book = bookRepository.findById(id).orElseThrow(() -> new BookNotFoundException("Book not found"));
+        return new BookResponse(book.getId(), book.getTitle(), book.getAuthor(), book.getAmount());
+    }
+
+    @Override
+    public List<BookResponse> getAllBooks() {
+        return bookRepository.findAll().stream()
+                .map(book -> new BookResponse(book.getId(), book.getTitle(), book.getAuthor(), book.getAmount()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public BookResponse updateBookById(Long id, UpdateBookRequest request) {
+        Book book = bookRepository.findById(id)
+                .orElseThrow(() -> new BookNotFoundException("Book not found"));
+        book.setTitle(request.title());
+        book.setAuthor(request.author());
+        book.setAmount(request.amount());
+        Book savedBook = bookRepository.save(book);
+        return new BookResponse(savedBook.getId(), savedBook.getTitle(), savedBook.getAuthor(), savedBook.getAmount());
+    }
+
+    @Override
+    public void deleteBookById(Long id) {
+        Book book = bookRepository.findById(id)
+                .orElseThrow(() -> new BookNotFoundException("Book not found"));
+
+        // TODO: if book is borrowed - throw an exception
+
+        bookRepository.delete(book);
+    }
 }

--- a/src/main/java/com/library/library_management/service/impl/BorrowServiceImpl.java
+++ b/src/main/java/com/library/library_management/service/impl/BorrowServiceImpl.java
@@ -1,0 +1,4 @@
+package com.library.library_management.service.impl;
+
+public class BorrowServiceImpl {
+}

--- a/src/main/java/com/library/library_management/service/impl/BorrowServiceImpl.java
+++ b/src/main/java/com/library/library_management/service/impl/BorrowServiceImpl.java
@@ -1,4 +1,102 @@
 package com.library.library_management.service.impl;
 
-public class BorrowServiceImpl {
+import com.library.library_management.dto.BookResponse;
+import com.library.library_management.dto.BorrowResponse;
+import com.library.library_management.dto.UpdateBookRequest;
+import com.library.library_management.dto.mapper.BookMapper;
+import com.library.library_management.dto.mapper.BorrowMapper;
+import com.library.library_management.entity.Book;
+import com.library.library_management.entity.Borrow;
+import com.library.library_management.entity.Member;
+import com.library.library_management.exception.BookNotAvailableException;
+import com.library.library_management.exception.BorrowLimitExceededException;
+import com.library.library_management.exception.BorrowNotFoundException;
+import com.library.library_management.exception.MemberNotFoundException;
+import com.library.library_management.repository.BorrowRepository;
+import com.library.library_management.repository.MemberRepository;
+import com.library.library_management.service.BookService;
+import com.library.library_management.service.BorrowService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class BorrowServiceImpl implements BorrowService {
+
+    // Limit of the borrowed books per member
+    @Value("${borrow.limit}")
+    private int borrowLimit;
+
+    @Autowired
+    private BorrowRepository borrowRepository;
+
+    @Autowired
+    private BookService bookService;
+
+    @Autowired
+    private BookMapper bookMapper;
+
+    @Autowired
+    private BorrowMapper borrowMapper;
+
+    // TODO: change to MemberService when its ready
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Override
+    public void borrowBook(Long memberId, Long bookId) {
+
+        BookResponse bookResponse = bookService.getBookById(bookId);
+        Book book = bookMapper.fromBookResponse(bookResponse);
+
+        if (book.getAmount() == 0) {
+            throw new BookNotAvailableException("Book is not available for borrowing");
+        }
+
+        int borrowCount = borrowRepository.countByMemberIdAndReturnDateIsNull(memberId);
+        if (borrowCount >= borrowLimit) {
+            throw new BorrowLimitExceededException("Member has reached the max borrow limit");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("Member not found"));
+
+        Borrow borrow = new Borrow(book, member, LocalDate.now());
+        borrowRepository.save(borrow);
+
+        book.setAmount(book.getAmount() - 1);
+        UpdateBookRequest request = bookMapper.toUpdateRequest(book);
+        bookService.updateBookById(book.getId(), request);
+    }
+
+    @Override
+    public void returnBook(Long borrowId) {
+        Borrow borrow = borrowRepository.findById(borrowId)
+                .orElseThrow(() -> new BorrowNotFoundException("Borrow not found"));
+        if (borrow.getReturnDate() != null) {
+            throw new IllegalStateException("Book already returned");
+        }
+
+        borrow.setReturnDate(LocalDate.now());
+        borrowRepository.save(borrow);
+
+        Book book = borrow.getBook();
+        book.setAmount(book.getAmount() + 1);
+        UpdateBookRequest updateRequest = bookMapper.toUpdateRequest(book);
+
+        bookService.updateBookById(book.getId(), updateRequest);
+    }
+
+    @Override
+    public List<BorrowResponse> getBorrowedBooksByMember(Long memberId) {
+        List<Borrow> borrows = borrowRepository.findByMemberIdAndReturnDateIsNull(memberId);
+        return borrows.stream().map(borrow -> borrowMapper.toResponse(borrow)).toList();
+    }
+
+    @Override
+    public boolean isBookCurrentlyBorrowed(Long bookId) {
+        return borrowRepository.existsByBookIdAndReturnDateIsNull(bookId);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+borrow.limit=${MAX_BORROWED_BOOKS}


### PR DESCRIPTION
This PR re-applies the borrow management feature branch using a regular merge instead of a squash merge.
Previously, the changes were merged as a squash merge which combined all commits into one, losing detailed commit history.